### PR TITLE
Initial support for edge flip 

### DIFF
--- a/include/rxmesh/kernels/collective.cuh
+++ b/include/rxmesh/kernels/collective.cuh
@@ -5,6 +5,7 @@
 #include "rxmesh/util/macros.h"
 
 namespace rxmesh {
+namespace detail {
 /**
  * @brief Compute block-wide exclusive sum using CUB
  */
@@ -93,5 +94,5 @@ __device__ __forceinline__ void cub_block_exclusive_sum(T*             data,
         data[size] = s_prv_run_aggregate;
     }*/
 }
-
+}  // namespace detail
 }  // namespace rxmesh

--- a/include/rxmesh/kernels/edge_flip.cuh
+++ b/include/rxmesh/kernels/edge_flip.cuh
@@ -1,0 +1,186 @@
+namespace rxmesh {
+
+namespace detail {
+/**
+ * @brief
+ */
+template <uint32_t blockThreads, typename predicateT>
+__device__ __inline__ void edge_flip(PatchInfo&       patch_info,
+                                     const predicateT predicate)
+{
+    // Extract the argument in the predicate lambda function
+    using PredicateTTraits = detail::FunctionTraits<predicateT>;
+    using HandleT          = typename PredicateTTraits::template arg<0>::type;
+    static_assert(
+        std::is_same_v<HandleT, EdgeHandle>,
+        "First argument in predicate lambda function should be EdgeHandle");
+
+    // patch basic info
+    const uint16_t num_faces       = patch_info.num_faces;
+    const uint16_t num_edges       = patch_info.num_edges;
+    const uint16_t num_owned_edges = patch_info.num_owned_edges;
+
+    // shared memory used to store EF, EV, FE, and info about the flipped edge
+    __shared__ uint16_t        s_num_flipped_edges;
+    extern __shared__ uint16_t shrd_mem[];
+    uint16_t*                  s_fe = shrd_mem;
+    uint16_t* s_ef      = &shrd_mem[3 * num_faces + (3 * num_faces) % 2];
+    uint16_t* s_ev      = s_ef;
+    uint16_t* s_flipped = &s_ef[2 * num_edges];
+
+    if (threadIdx.x == 0) {
+        s_num_flipped_edges = 0;
+    }
+    // Initialize EF to invalid values
+    // Cast EF into 32-but to fix the bank conflicts
+    uint32_t* s_ef32 = reinterpret_cast<uint32_t*>(s_ef);
+    for (uint16_t i = threadIdx.x; i < num_edges; i += blockThreads) {
+        s_ef32[i] = INVALID32;
+    }
+
+    // load FE into shared memory
+    load_patch_FE<blockThreads>(patch_info,
+                                reinterpret_cast<LocalEdgeT*>(s_fe));
+    __syncthreads();
+
+    // Transpose FE into EF so we obtain the two incident triangles to
+    // to-be-flipped edges. We use the version that is optimized for
+    // manifolds (we don't flip non-manifold edges)
+    e_f_manifold<blockThreads>(num_edges, num_faces, s_fe, s_ef);
+    __syncthreads();
+
+    // load over all edges---one thread per edge
+    uint16_t local_id = threadIdx.x;
+    while (local_id < num_owned_edges) {
+
+        // check if we should flip this edge based on the user-supplied
+        // predicate
+        if (predicate({patch_info.patch_id, local_id})) {
+
+            // read the two faces incident to this edge
+            const uint16_t f0 = s_ef[2 * local_id];
+            const uint16_t f1 = s_ef[2 * local_id + 1];
+
+            // if the edge is boundary (i.e., only incident to one face), then
+            // we don't flip
+            if (f0 != INVALID16 && f1 != INVALID16) {
+                const uint16_t flipped_id = atomicAdd(&s_num_flipped_edges, 1);
+
+                // for each flipped edge, we add it to shared memory buffer
+                // along with one of its incident faces
+                s_flipped[2 * flipped_id]     = local_id;
+                s_flipped[2 * flipped_id + 1] = f0;
+
+                // the three edges incident to the first face
+                uint16_t f0_e[3];
+                f0_e[0] = s_fe[3 * f0];
+                f0_e[1] = s_fe[3 * f0 + 1];
+                f0_e[2] = s_fe[3 * f0 + 2];
+
+                // the flipped edge position in first face
+                const uint16_t l0 = ((f0_e[0] >> 1) == local_id) ?
+                                        0 :
+                                        (((f0_e[1] >> 1) == local_id) ? 1 : 2);
+
+                // the three edges incident to the second face
+                uint16_t f1_e[3];
+                f1_e[0] = s_fe[3 * f1];
+                f1_e[1] = s_fe[3 * f1 + 1];
+                f1_e[2] = s_fe[3 * f1 + 2];
+
+                // the flipped edge position in second face
+                const uint16_t l1 = ((f1_e[0] >> 1) == local_id) ?
+                                        0 :
+                                        (((f1_e[1] >> 1) == local_id) ? 1 : 2);
+
+                const uint16_t f0_shift = 3 * f0;
+                const uint16_t f1_shift = 3 * f1;
+
+                s_fe[f0_shift + ((l0 + 1) % 3)] = f0_e[l0];
+                s_fe[f1_shift + ((l1 + 1) % 3)] = f1_e[l1];
+
+                s_fe[f1_shift + l1] = f0_e[(l0 + 1) % 3];
+                s_fe[f0_shift + l0] = f1_e[(l1 + 1) % 3];
+            }
+        }
+        local_id += blockThreads;
+    }
+    __syncthreads();
+
+    // If flipped at least one edge
+    if (s_num_flipped_edges > 0) {
+        // we store the changes we made to FE in global memory
+        detail::load_uint16<blockThreads>(
+            s_fe, 3 * num_faces, reinterpret_cast<uint16_t*>(patch_info.fe));
+
+        // load EV in the same place that was used to store EF
+        load_patch_EV<blockThreads>(patch_info,
+                                    reinterpret_cast<LocalVertexT*>(s_ev));
+        __syncthreads();
+
+        // Now, we go over all edge that has been flipped
+        for (uint32_t e = threadIdx.x; e < s_num_flipped_edges;
+             e += blockThreads) {
+
+            // grab the edge that was flipped and one of its incident faces
+            const uint16_t edge = s_flipped[2 * e];
+            const uint16_t face = s_flipped[2 * e + 1];
+
+            // grab the three edges incident to this face
+            uint16_t fe[3];
+            fe[0] = s_fe[3 * face];
+            fe[1] = s_fe[3 * face + 1];
+            fe[2] = s_fe[3 * face + 2];
+
+            // find the flipped edge's position in this face incident edges
+            const uint16_t l =
+                ((fe[0] >> 1) == edge) ? 0 : (((fe[1] >> 1) == edge) ? 1 : 2);
+
+            // find which edge is next and which is before the flipped edge
+            // in this face incident edge
+            const uint16_t next_edge = fe[(l + 1) % 3];
+            const uint16_t prev_edge = fe[(l + 2) % 3];
+
+            // grab the two end vertices of the next edge
+            uint16_t next_edge_v[2];
+            next_edge_v[0] = s_ev[2 * (next_edge >> 1)];
+            next_edge_v[1] = s_ev[2 * (next_edge >> 1) + 1];
+
+            // grab the two end vertices of the previous edge
+            uint16_t prev_edge_v[2];
+            prev_edge_v[0] = s_ev[2 * (prev_edge >> 1)];
+            prev_edge_v[1] = s_ev[2 * (prev_edge >> 1) + 1];
+
+            // Find which vertex from the next edge that is not common between
+            // the two incident vertices in the next and previous edges
+            const uint16_t n = (next_edge_v[0] == prev_edge_v[0] ||
+                                next_edge_v[0] == prev_edge_v[1]) ?
+                                   next_edge_v[1] :
+                                   next_edge_v[0];
+
+            // Find which vertex from the previous edge that is not common
+            // between the two incident vertices in the next and previous edges
+            const uint16_t p = (prev_edge_v[0] == next_edge_v[0] ||
+                                prev_edge_v[0] == next_edge_v[1]) ?
+                                   prev_edge_v[1] :
+                                   prev_edge_v[0];
+
+            // The flipped edge connects p and n vertices. The order depends on
+            // the edge direction
+            if ((fe[l] & 1)) {
+                s_ev[2 * e]     = n;
+                s_ev[2 * e + 1] = p;
+            } else {
+                s_ev[2 * e]     = p;
+                s_ev[2 * e + 1] = n;
+            }
+        }
+
+        // We store the changes in EV to global memory
+        __syncthreads();
+        detail::load_uint16<blockThreads>(
+            s_ev, num_edges * 2, reinterpret_cast<uint16_t*>(patch_info.ev));
+    }
+}
+}  // namespace detail
+}  // namespace rxmesh

--- a/include/rxmesh/kernels/loader.cuh
+++ b/include/rxmesh/kernels/loader.cuh
@@ -56,15 +56,9 @@ template <uint32_t blockThreads>
 __device__ __forceinline__ void load_patch_EV(const PatchInfo& patch_info,
                                               LocalVertexT*    ev)
 {
-    const uint32_t  num_edges = patch_info.num_edges;
-    const uint32_t* input_ev32 =
-        reinterpret_cast<const uint32_t*>(patch_info.ev);
-    uint32_t* output_ev32 = reinterpret_cast<uint32_t*>(ev);
-#pragma unroll 2
-    for (uint32_t i = threadIdx.x; i < num_edges; i += blockThreads) {
-        uint32_t a     = input_ev32[i];
-        output_ev32[i] = a;
-    }
+    load_uint16<blockThreads>(reinterpret_cast<const uint16_t*>(patch_info.ev),
+                              patch_info.num_edges * 2,
+                              reinterpret_cast<uint16_t*>(ev));
 }
 
 /**

--- a/include/rxmesh/kernels/loader.cuh
+++ b/include/rxmesh/kernels/loader.cuh
@@ -7,6 +7,7 @@
 #include "rxmesh/types.h"
 
 namespace rxmesh {
+namespace detail {
 
 template <uint32_t blockThreads>
 __device__ __forceinline__ void load_uint16(const uint16_t* in,
@@ -275,5 +276,5 @@ __device__ __forceinline__ void load_not_owned(const PatchInfo& patch_info,
         }
     }
 }
-
+}  // namespace detail
 }  // namespace rxmesh

--- a/include/rxmesh/kernels/query_dispatcher.cuh
+++ b/include/rxmesh/kernels/query_dispatcher.cuh
@@ -158,7 +158,7 @@ __device__ __inline__ void query_block_dispatcher(const Context& context,
     uint32_t* not_owned_patch(nullptr);
     uint16_t* not_owned_local_id(nullptr);
 
-    detail::template query_block_dispatcher<op, blockThreads>(
+    query_block_dispatcher<op, blockThreads>(
         context.get_patches_info()[patch_id],
         compute_active_set,
         oriented,

--- a/include/rxmesh/kernels/rxmesh_queries.cuh
+++ b/include/rxmesh/kernels/rxmesh_queries.cuh
@@ -10,6 +10,8 @@
 #include "rxmesh/types.h"
 
 namespace rxmesh {
+namespace detail {
+
 template <uint32_t rowOffset,
           uint32_t blockThreads,
           uint32_t itemPerThread = TRANSPOSE_ITEM_PER_THREAD>
@@ -526,5 +528,5 @@ __device__ __forceinline__ void query(uint16_t*&     s_output_offset,
             break;
     }
 }
-
+}  // namespace detail
 }  // namespace rxmesh

--- a/include/rxmesh/kernels/update_dispatcher.cuh
+++ b/include/rxmesh/kernels/update_dispatcher.cuh
@@ -2,172 +2,45 @@
 
 #include "rxmesh/context.h"
 #include "rxmesh/handle.h"
+#include "rxmesh/kernels/edge_flip.cuh"
 #include "rxmesh/kernels/loader.cuh"
 #include "rxmesh/patch_info.h"
 #include "rxmesh/util/meta.h"
 
 namespace rxmesh {
 
-namespace detail {
 /**
- * @brief
+ * @brief The main entry for update operations. This function should be called
+ * by the whole block. In this function, threads will be assigned to mesh
+ * elements depending on the update operations.The user should supply a
+ * predicate lambda function that check if the update operation should be done
+ * on the input mesh element.
+ * @tparam DynOp the type of update operation
+ * @tparam blockThreads the number of CUDA threads in the block
+ * @tparam predicateT the type of predicate lambda function (inferred)
+ * @param context which store various parameters needed for the update
+ * operation. The context can be obtained from RXMeshDynamic
+ * @param predicate the predicate lambda function that will be executed by
+ * each thread in the block. This lambda function takes one input parameters
+ * which is a handle depending on the update operations e.g., EdgeHandle for
+ * edge flip. This lambda function should return a boolean that is true only if
+ * the update operation should be done on the give mesh element
  */
-template <uint32_t blockThreads, typename flipT>
-__device__ __inline__ void edge_flip_block_dispatcher(PatchInfo&  patch_info,
-                                                      const flipT flip)
+template <DynOp op, uint32_t blockThreads, typename predicateT>
+__device__ __inline__ void update_block_dispatcher(const Context&   context,
+                                                   const predicateT predicate)
 {
-    __shared__ uint16_t s_num_flipped_edges;
-    const uint16_t      num_faces       = patch_info.num_faces;
-    const uint16_t      num_edges       = patch_info.num_edges;
-    const uint16_t      num_owned_edges = patch_info.num_owned_edges;
 
-    // load the patch
-    extern __shared__ uint16_t shrd_mem[];
-    uint16_t*                  s_fe = shrd_mem;
-    uint16_t* s_ef      = &shrd_mem[3 * num_faces + (3 * num_faces) % 2];
-    uint16_t* s_ev      = s_ef;
-    uint16_t* s_flipped = &s_ef[2 * num_edges];
+    const uint32_t patch_id = blockIdx.x;
 
-    if (threadIdx.x == 0) {
-        s_num_flipped_edges = 0;
-    }
-    // to fix the bank conflicts
-    uint32_t* s_ef32 = reinterpret_cast<uint32_t*>(s_ef);
-    for (uint16_t i = threadIdx.x; i < num_edges; i += blockThreads) {
-        s_ef32[i] = INVALID32;
-    }
-    load_patch_FE<blockThreads>(patch_info,
-                                reinterpret_cast<LocalEdgeT*>(s_fe));
-    __syncthreads();
-
-    // Transpose FE into EF so we obtain the two incident triangles to
-    // the flipped edges. We use the version that is optimized for
-    // manifolds
-    e_f_manifold<blockThreads>(num_edges, num_faces, s_fe, s_ef);
-    __syncthreads();
-
-
-    uint16_t local_id = threadIdx.x;
-    while (local_id < num_owned_edges) {
-
-        if (flip({patch_info.patch_id, local_id})) {
-            const uint16_t f0 = s_ef[2 * local_id];
-            const uint16_t f1 = s_ef[2 * local_id + 1];
-            if (f0 != INVALID16 && f1 != INVALID16) {
-
-                const uint16_t flipped_id = atomicAdd(&s_num_flipped_edges, 1);
-
-                s_flipped[2 * flipped_id]     = local_id;
-                s_flipped[2 * flipped_id + 1] = f0;
-
-                uint16_t f0_e[3];
-                f0_e[0] = s_fe[3 * f0];
-                f0_e[1] = s_fe[3 * f0 + 1];
-                f0_e[2] = s_fe[3 * f0 + 2];
-
-                const uint16_t l0 = ((f0_e[0] >> 1) == local_id) ?
-                                        0 :
-                                        (((f0_e[1] >> 1) == local_id) ? 1 : 2);
-
-                uint16_t f1_e[3];
-                f1_e[0] = s_fe[3 * f1];
-                f1_e[1] = s_fe[3 * f1 + 1];
-                f1_e[2] = s_fe[3 * f1 + 2];
-
-                const uint16_t l1 = ((f1_e[0] >> 1) == local_id) ?
-                                        0 :
-                                        (((f1_e[1] >> 1) == local_id) ? 1 : 2);
-
-                const uint16_t f0_shift = 3 * f0;
-                const uint16_t f1_shift = 3 * f1;
-
-
-                s_fe[f0_shift + ((l0 + 1) % 3)] = f0_e[l0];
-                s_fe[f1_shift + ((l1 + 1) % 3)] = f1_e[l1];
-
-                s_fe[f1_shift + l1] = f0_e[(l0 + 1) % 3];
-                s_fe[f0_shift + l0] = f1_e[(l1 + 1) % 3];
-            }
-        }
-        local_id += blockThreads;
-    }
-
-
-    __syncthreads();
-    load_uint16<blockThreads>(
-        s_fe, 3 * num_faces, reinterpret_cast<uint16_t*>(patch_info.fe));
-
-    if (s_num_flipped_edges > 0) {
-        load_patch_EV<blockThreads>(patch_info,
-                                    reinterpret_cast<LocalVertexT*>(s_ev));
-        __syncthreads();
-    }
-    for (uint32_t e = threadIdx.x; e < s_num_flipped_edges; e += blockThreads) {
-        const uint16_t edge = s_flipped[2 * e];
-        const uint16_t face = s_flipped[2 * e + 1];
-
-        uint16_t fe[3];
-        fe[0] = s_fe[3 * face];
-        fe[1] = s_fe[3 * face + 1];
-        fe[2] = s_fe[3 * face + 2];
-
-        const uint16_t l =
-            ((fe[0] >> 1) == edge) ? 0 : (((fe[1] >> 1) == edge) ? 1 : 2);
-
-        const uint16_t next_edge = fe[(l + 1) % 3];
-        const uint16_t prev_edge = fe[(l + 2) % 3];
-
-        uint16_t next_edge_v[2];
-        next_edge_v[0] = s_ev[2 * (next_edge >> 1)];
-        next_edge_v[1] = s_ev[2 * (next_edge >> 1) + 1];
-
-        uint16_t prev_edge_v[2];
-        prev_edge_v[0] = s_ev[2 * (prev_edge >> 1)];
-        prev_edge_v[1] = s_ev[2 * (prev_edge >> 1) + 1];
-
-        const uint16_t n = (next_edge_v[0] == prev_edge_v[0] ||
-                            next_edge_v[0] == prev_edge_v[1]) ?
-                               next_edge_v[1] :
-                               next_edge_v[0];
-
-        const uint16_t p = (prev_edge_v[0] == next_edge_v[0] ||
-                            prev_edge_v[0] == next_edge_v[1]) ?
-                               prev_edge_v[1] :
-                               prev_edge_v[0];
-
-        s_ev[2 * e]     = n;
-        s_ev[2 * e + 1] = p;
-    }
-
-    __syncthreads();
-
-    load_uint16<blockThreads>(
-        s_ev, num_edges * 2, reinterpret_cast<uint16_t*>(patch_info.ev));
-}
-}  // namespace detail
-
-/**
- * @brief
- */
-template <uint32_t blockThreads, typename flipT>
-__device__ __inline__ void edge_flip_block_dispatcher(const Context& context,
-                                                      const flipT    flip)
-{
-    // Extract the argument in the flip lambda function
-    using FlipTraits = detail::FunctionTraits<flipT>;
-    using HandleT    = typename FlipTraits::template arg<0>::type;
-    static_assert(
-        std::is_same_v<HandleT, EdgeHandle>,
-        "First argument in flip lambda function should be EdgeHandle");
-
-
-    if (blockIdx.x >= context.get_num_patches()) {
+    if (patch_id >= context.get_num_patches()) {
         return;
     }
 
-    const uint32_t patch_id = blockIdx.x;
-    detail::edge_flip_block_dispatcher<blockThreads>(
-        context.get_patches_info()[patch_id], flip);
+    if constexpr (op == DynOp::EdgeFlip) {
+        detail::edge_flip<blockThreads>(context.get_patches_info()[patch_id],
+                                        predicate);
+    }
 }
 
 }  // namespace rxmesh

--- a/include/rxmesh/kernels/update_dispatcher.cuh
+++ b/include/rxmesh/kernels/update_dispatcher.cuh
@@ -1,0 +1,46 @@
+#pragma
+
+#include "rxmesh/context.h"
+#include "rxmesh/handle.h"
+#include "rxmesh/patch_info.h"
+#include "rxmesh/util/meta.h"
+
+namespace rxmesh {
+
+namespace detail {
+/**
+ * @brief
+ */
+template <uint32_t blockThreads, typename flipT>
+__device__ __inline__ void edge_flip_block_dispatcher(PatchInfo&  patch_info,
+                                                      const flipT flip)
+{
+
+}
+}  // namespace detail
+
+/**
+ * @brief
+ */
+template <uint32_t blockThreads, typename flipT>
+__device__ __inline__ void edge_flip_block_dispatcher(const Context& context,
+                                                      const flipT    flip)
+{
+    // Extract the argument in the flip lambda function
+    using FlipTraits = detail::FunctionTraits<flipT>;
+    using HandleT    = typename FlipTraits::template arg<0>::type;
+    static_assert(
+        std::is_same_v<HandleT, EdgeHandle>,
+        "First argument in flip lambda function should be EdgeHandle");
+
+
+    if (blockIdx.x >= context.get_num_patches()) {
+        return;
+    }
+
+    const uint32_t patch_id = blockIdx.x;
+    detail::edge_flip_block_dispatcher<blockThreads>(
+        context.get_patches_info()[patch_id], flip);
+}
+
+}  // namespace rxmesh

--- a/include/rxmesh/kernels/update_dispatcher.cuh
+++ b/include/rxmesh/kernels/update_dispatcher.cuh
@@ -2,6 +2,7 @@
 
 #include "rxmesh/context.h"
 #include "rxmesh/handle.h"
+#include "rxmesh/kernels/loader.cuh"
 #include "rxmesh/patch_info.h"
 #include "rxmesh/util/meta.h"
 
@@ -15,7 +16,63 @@ template <uint32_t blockThreads, typename flipT>
 __device__ __inline__ void edge_flip_block_dispatcher(PatchInfo&  patch_info,
                                                       const flipT flip)
 {
+    bool do_flip[EDGE_FLIP_PER_THREAD];
 
+    for (uint32_t i = 0; i < EDGE_FLIP_PER_THREAD; ++i) {
+        do_flip[i] = false;
+    }
+
+    assert(EDGE_FLIP_PER_THREAD * blockThreads >= patch_info.num_owned_edges);
+
+    // compute the predicate for each edge assigned to this thread and cache
+    // the results in do_flip.
+    bool     any_flip = false;
+    uint16_t local_id = threadIdx.x;
+    uint32_t e        = 0;
+    while (local_id < patch_info.num_owned_edges) {
+        do_flip[e] = flip({patch_info.patch_id, local_id});
+        any_flip   = any_flip || do_flip[e];
+
+        local_id += blockThreads;
+        e++;
+    }
+
+    if (__syncthreads_or(any_flip) == 0) {
+        return;
+    }
+
+    // we have at least on edge to flip in this patch
+    extern __shared__ uint16_t shrd_mem[];
+    LocalVertexT*              s_ev = reinterpret_cast<LocalVertexT*>(shrd_mem);
+    LocalEdgeT*                s_fe = reinterpret_cast<LocalEdgeT*>(shrd_mem);
+    uint16_t*                  s_ef = reinterpret_cast<uint16_t*>(
+        &shrd_mem[3 * patch_info.num_faces + (3 * patch_info.num_faces) % 2]);
+
+    // first load and update
+    load_patch_FE<blockThreads>(patch_info, s_fe);
+
+    // 1. transpose FE into EF so we obtain the two incident triangles to the
+    // flipped edges. We can optimize this for manifold mesh
+    for (uint16_t e = threadIdx.x; e < 3 * patch_info.num_faces;
+         e += blockThreads) {
+        uint16_t edge    = s_fe[e].id >> 1;
+        uint16_t face_id = e / 3;
+
+        auto ret = atomicCAS(s_ef + 2 * edge, INVALID16, face_id);
+        if (ret != INVALID16) {
+            ret = atomicCAS(s_ef + 2 * edge + 1, INVALID16, face_id);
+            assert(ret == INVALID16);
+        }
+    }
+
+    local_id = threadIdx.x;
+    e        = 0;
+    while (local_id < patch_info.num_owned_edges) {
+        if (do_flip[e]) {
+        }
+        local_id += blockThreads;
+        e++;
+    }
 }
 }  // namespace detail
 

--- a/include/rxmesh/kernels/update_dispatcher.cuh
+++ b/include/rxmesh/kernels/update_dispatcher.cuh
@@ -74,25 +74,32 @@ __device__ __inline__ void edge_flip_block_dispatcher(PatchInfo&  patch_info,
             const uint16_t f0 = s_ef[2 * local_id];
             const uint16_t f1 = s_ef[2 * local_id + 1];
 
-            const uint16_t f0_e0 = s_fe[3 * f0];
-            const uint16_t f0_e1 = s_fe[3 * f0 + 1];
-            const uint16_t f0_e2 = s_fe[3 * f0 + 2];
+            uint16_t f0_e[3];
+            f0_e[0] = s_fe[3 * f0];
+            f0_e[1] = s_fe[3 * f0 + 1];
+            f0_e[2] = s_fe[3 * f0 + 2];
 
-            const uint16_t l0 = ((f0_e0 >> 1) == local_id) ?
+            const uint16_t l0 = ((f0_e[0] >> 1) == local_id) ?
                                     0 :
-                                    (((f0_e1 >> 1) == local_id) ? 1 : 2);
+                                    (((f0_e[1] >> 1) == local_id) ? 1 : 2);
 
-            const uint16_t f1_e0 = s_fe[3 * f1];
-            const uint16_t f1_e1 = s_fe[3 * f1 + 1];
-            const uint16_t f1_e2 = s_fe[3 * f1 + 2];
+            uint16_t f1_e[3];
+            f1_e[0] = s_fe[3 * f1];
+            f1_e[1] = s_fe[3 * f1 + 1];
+            f1_e[2] = s_fe[3 * f1 + 2];
 
-            const uint16_t l1 = ((f1_e0 >> 1) == local_id) ?
+            const uint16_t l1 = ((f1_e[0] >> 1) == local_id) ?
                                     0 :
-                                    (((f1_e1 >> 1) == local_id) ? 1 : 2);
+                                    (((f1_e[1] >> 1) == local_id) ? 1 : 2);
 
-            const uint16_t shift = (local_id / 3) * 3;
+            const uint16_t f0_shift = (f0 / 3) * 3;
+            const uint16_t f1_shift = (f1 / 3) * 3;
 
-            //s_fe[shift + ((l0 +1)%3)] = 
+            s_fe[f0_shift + ((l0 + 1) % 3)] = f0_e[l0];
+            s_fe[f1_shift + ((l1 + 1) % 3)] = f1_e[l1];
+
+            s_fe[f1_shift + l0] = f0_e[(l0 + 1) % 3];
+            s_fe[f0_shift + l1] = f1_e[(l1 + 1) % 3];
         }
         local_id += blockThreads;
         e++;

--- a/include/rxmesh/rxmesh_dynamic.h
+++ b/include/rxmesh/rxmesh_dynamic.h
@@ -19,6 +19,46 @@ class RXMeshDynamic : public RXMeshStatic
     {
     }
 
+
+    template <uint32_t blockThreads>
+    void prepare_launch_box(const std::vector<Op>    op,
+                            LaunchBox<blockThreads>& launch_box,
+                            const void*              kernel,
+                            const bool               oriented = false) const
+    {
+        // If there is no query operations, we at least need to load the patch
+        // EV and FE. Otherwise, we need to make sure that we at least can load
+        // EV and FE after performing the queries (TODO)
+
+        launch_box.blocks         = this->m_num_patches;
+        launch_box.smem_bytes_dyn = 0;
+
+        if (op.empty()) {
+            // load FE and EV
+            launch_box.smem_bytes_dyn =
+                3 * this->m_max_faces_per_patch * sizeof(uint16_t);
+            launch_box.smem_bytes_dyn +=
+                2 * this->m_max_edges_per_patch * sizeof(uint16_t);
+        } else {
+            RXMESH_ERROR(
+                "RXMeshDynamic::prepare_launch_box() doing query with updates "
+                "is not supported yet!");
+        }
+
+        if (!this->m_quite) {
+            RXMESH_TRACE(
+                "RXMeshDynamic::calc_shared_memory() launching {} blocks with "
+                "{} threads on the device",
+                launch_box.blocks,
+                blockThreads);
+        }
+
+        check_shared_memory(launch_box.smem_bytes_dyn,
+                            launch_box.smem_bytes_static,
+                            launch_box.num_registers_per_thread,
+                            kernel);
+    }
+
     virtual ~RXMeshDynamic() = default;
 };
 }  // namespace rxmesh

--- a/include/rxmesh/rxmesh_dynamic.h
+++ b/include/rxmesh/rxmesh_dynamic.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "rxmesh/rxmesh_static.h"
+
+namespace rxmesh {
+
+class RXMeshDynamic : public RXMeshStatic
+{
+   public:
+    RXMeshDynamic(const RXMeshDynamic&) = delete;
+
+    /**
+     * @brief Main constructor used to initialize internal member variables
+     * @param fv Face incident vertices as read from an obj file
+     * @param quite run in quite mode
+     */
+    RXMeshDynamic(std::vector<std::vector<uint32_t>>& fv,
+                  const bool                          quite = false)
+        : RXMeshStatic(fv, quite)
+    {
+    }
+
+    virtual ~RXMeshDynamic() = default;
+};
+}  // namespace rxmesh

--- a/include/rxmesh/rxmesh_dynamic.h
+++ b/include/rxmesh/rxmesh_dynamic.h
@@ -75,12 +75,14 @@ class RXMeshDynamic : public RXMeshStatic
 
         size_t dynamic_smem = 0;
         if (op == DynOp::EdgeFlip) {
-            // load FE, than transpose it into EF, then update FE. Thus, we need
+            // load FE, then transpose it into EF, then update FE. Thus, we need
             // to have both in memory at one point. Then, load EV and update it
             dynamic_smem = 3 * this->m_max_faces_per_patch * sizeof(uint16_t);
-            dynamic_smem +=
-                std::max(2 * this->m_max_edges_per_patch * sizeof(uint16_t),
-                         3 * this->m_max_faces_per_patch * sizeof(uint16_t));
+            dynamic_smem += 2 * this->m_max_edges_per_patch * sizeof(uint16_t);
+            dynamic_smem += DIVIDE_UP(this->m_max_faces_per_patch -
+                                          this->m_max_not_owned_faces,
+                                      2) *
+                            2 * sizeof(uint16_t);
         }
 
         return dynamic_smem;

--- a/include/rxmesh/rxmesh_static.h
+++ b/include/rxmesh/rxmesh_static.h
@@ -193,10 +193,9 @@ class RXMeshStatic : public RXMesh
         launch_box.smem_bytes_dyn = 0;
 
         for (auto o : op) {
-            launch_box.smem_bytes_dyn =
-                std::max(launch_box.smem_bytes_dyn,
-                         this->template calc_shared_memory<blockThreads>(
-                             o, kernel, oriented));
+            launch_box.smem_bytes_dyn = std::max(
+                launch_box.smem_bytes_dyn,
+                this->template calc_shared_memory<blockThreads>(o, oriented));
         }
 
         if (!this->m_quite) {
@@ -658,9 +657,7 @@ class RXMeshStatic : public RXMesh
 
    protected:
     template <uint32_t blockThreads>
-    size_t calc_shared_memory(const Op    op,
-                              const void* kernel,
-                              const bool  oriented = false) const
+    size_t calc_shared_memory(const Op op, const bool oriented = false) const
     {
         // Operations that uses matrix transpose needs a template parameter
         // that is by default TRANSPOSE_ITEM_PER_THREAD. Here we check if

--- a/include/rxmesh/types.h
+++ b/include/rxmesh/types.h
@@ -75,7 +75,7 @@ enum class ELEMENT
 };
 
 /**
- * @brief Various query operations supported in RXMesh
+ * @brief Various query operations supported in RXMeshStatic
  */
 enum class Op
 {
@@ -90,6 +90,14 @@ enum class Op
     EF = 8,
 };
 
+
+/**
+ * @brief different dynaimc operators supported in RXMeshDynamic
+ */
+enum class DynOp
+{
+    EdgeFlip = 0,
+};
 /**
  * @brief Convert an operation to string
  * @param op a query operation

--- a/include/rxmesh/util/macros.h
+++ b/include/rxmesh/util/macros.h
@@ -8,6 +8,9 @@ namespace rxmesh {
 
 typedef uint8_t flag_t;
 
+// number of edges assigned to a thread for edge flip dispatcher
+constexpr uint32_t EDGE_FLIP_PER_THREAD = 3;
+
 // TRANSPOSE_ITEM_PER_THREAD
 constexpr uint32_t TRANSPOSE_ITEM_PER_THREAD = 11;
 
@@ -66,7 +69,8 @@ inline void HandleError(cudaError_t err, const char* file, int line)
 #endif
 
 
-//Taken from https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#extended-lambda-traits
+// Taken from
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#extended-lambda-traits
 #define IS_D_LAMBDA(X) __nv_is_extended_device_lambda_closure_type(X)
 #define IS_HD_LAMBDA(X) __nv_is_extended_host_device_lambda_closure_type(X)
 

--- a/include/rxmesh/util/macros.h
+++ b/include/rxmesh/util/macros.h
@@ -8,9 +8,6 @@ namespace rxmesh {
 
 typedef uint8_t flag_t;
 
-// number of edges assigned to a thread for edge flip dispatcher
-constexpr uint32_t EDGE_FLIP_PER_THREAD = 3;
-
 // TRANSPOSE_ITEM_PER_THREAD
 constexpr uint32_t TRANSPOSE_ITEM_PER_THREAD = 11;
 

--- a/tests/RXMesh_test/CMakeLists.txt
+++ b/tests/RXMesh_test/CMakeLists.txt
@@ -12,6 +12,8 @@ set( SOURCE_LIST
 	query.cuh	
 	higher_query.cuh
 	test_for_each.h
+	test_edge_flip.h
+	edge_flip.cuh
 )
 
 target_sources( RXMesh_test 

--- a/tests/RXMesh_test/edge_flip.cuh
+++ b/tests/RXMesh_test/edge_flip.cuh
@@ -7,4 +7,15 @@ template <uint32_t blockThreads>
 __global__ static void edge_flip(rxmesh::Context context)
 {
     using namespace rxmesh;
+
+    // flip one edge (the edge assigned to thread 0) in each patch
+    auto should_flip = [&](const EdgeHandle& edge) -> bool {
+        if (threadIdx.x == 0) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    edge_flip_block_dispatcher<blockThreads>(context, should_flip);
 }

--- a/tests/RXMesh_test/edge_flip.cuh
+++ b/tests/RXMesh_test/edge_flip.cuh
@@ -17,5 +17,6 @@ __global__ static void edge_flip(rxmesh::Context context)
         }
     };
 
-    edge_flip_block_dispatcher<blockThreads>(context, should_flip);
+    update_block_dispatcher<DynOp::EdgeFlip, blockThreads>(context,
+                                                           should_flip);
 }

--- a/tests/RXMesh_test/edge_flip.cuh
+++ b/tests/RXMesh_test/edge_flip.cuh
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "rxmesh/context.h"
+#include "rxmesh/kernels/update_dispatcher.cuh"
+
+template <uint32_t blockThreads>
+__global__ static void edge_flip(rxmesh::Context context)
+{
+    using namespace rxmesh;
+}

--- a/tests/RXMesh_test/rxmesh_test_main.cu
+++ b/tests/RXMesh_test/rxmesh_test_main.cu
@@ -21,6 +21,7 @@ struct RXMeshTestArg
 #include "test_queries.h"
 #include "test_attribute.cuh"
 #include "test_for_each.h"
+#include "test_edge_flip.h"
 
 int main(int argc, char** argv)
 {

--- a/tests/RXMesh_test/test_edge_flip.h
+++ b/tests/RXMesh_test/test_edge_flip.h
@@ -16,5 +16,8 @@ TEST(RXMeshDynamic, EdgeFlip)
 
     RXMeshDynamic rxmesh(Faces, rxmesh_args.quite);
 
+    constexpr uint32_t blockThreads = 256;
 
+    edge_flip<blockThreads>
+        <<<rxmesh.get_num_patches(), blockThreads>>>(rxmesh.get_context());
 }

--- a/tests/RXMesh_test/test_edge_flip.h
+++ b/tests/RXMesh_test/test_edge_flip.h
@@ -16,9 +16,12 @@ TEST(RXMeshDynamic, EdgeFlip)
 
     RXMeshDynamic rxmesh(Faces, rxmesh_args.quite);
 
+    ASSERT_TRUE(rxmesh.is_edge_manifold());
+
     constexpr uint32_t      blockThreads = 256;
     LaunchBox<blockThreads> launch_box;
-    rxmesh.prepare_launch_box({}, launch_box, (void*)edge_flip<blockThreads>);
+    rxmesh.prepare_launch_box(
+        {}, {DynOp::EdgeFlip}, launch_box, (void*)edge_flip<blockThreads>);
 
     edge_flip<blockThreads>
         <<<launch_box.blocks, blockThreads, launch_box.smem_bytes_dyn>>>(

--- a/tests/RXMesh_test/test_edge_flip.h
+++ b/tests/RXMesh_test/test_edge_flip.h
@@ -1,0 +1,20 @@
+#include "gtest/gtest.h"
+
+#include "edge_flip.cuh"
+#include "rxmesh/rxmesh_dynamic.h"
+
+TEST(RXMeshDynamic, EdgeFlip)
+{
+    using namespace rxmesh;
+
+    cuda_query(rxmesh_args.device_id, rxmesh_args.quite);
+
+    std::vector<std::vector<dataT>>    Verts;
+    std::vector<std::vector<uint32_t>> Faces;
+    ASSERT_TRUE(import_obj(
+        STRINGIFY(INPUT_DIR) "sphere3.obj", Verts, Faces, rxmesh_args.quite));
+
+    RXMeshDynamic rxmesh(Faces, rxmesh_args.quite);
+
+
+}

--- a/tests/RXMesh_test/test_edge_flip.h
+++ b/tests/RXMesh_test/test_edge_flip.h
@@ -16,8 +16,11 @@ TEST(RXMeshDynamic, EdgeFlip)
 
     RXMeshDynamic rxmesh(Faces, rxmesh_args.quite);
 
-    constexpr uint32_t blockThreads = 256;
+    constexpr uint32_t      blockThreads = 256;
+    LaunchBox<blockThreads> launch_box;
+    rxmesh.prepare_launch_box({}, launch_box, (void*)edge_flip<blockThreads>);
 
     edge_flip<blockThreads>
-        <<<rxmesh.get_num_patches(), blockThreads>>>(rxmesh.get_context());
+        <<<launch_box.blocks, blockThreads, launch_box.smem_bytes_dyn>>>(
+            rxmesh.get_context());
 }

--- a/tests/RXMesh_test/test_util.cu
+++ b/tests/RXMesh_test/test_util.cu
@@ -12,14 +12,14 @@ __global__ static void k_test_block_mat_transpose(uint16_t*      d_src,
                                                   uint16_t*      d_output)
 {
 
-    rxmesh::block_mat_transpose<rowOffset, blockThreads, itemPerThread>(
+    rxmesh::detail::block_mat_transpose<rowOffset, blockThreads, itemPerThread>(
         num_rows, num_cols, d_src, d_output);
 }
 
 template <typename T, uint32_t blockThreads>
 __global__ static void k_test_block_exclusive_sum(T* d_src, const uint32_t size)
 {
-    rxmesh::cub_block_exclusive_sum<T, blockThreads>(d_src, size);
+    rxmesh::detail::cub_block_exclusive_sum<T, blockThreads>(d_src, size);
 }
 
 template <typename T>


### PR DESCRIPTION
This PR introduces `RXMeshDynamic` as a first step to support dynamic updates. For now, the user should make sure that an edge flip does not introduce invalid configuration. 