### PR TITLE
Initial support to use `memcpy_async`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,8 @@ set(cuda_flags
 	-use_fast_math	
     $<$<CXX_COMPILER_ID:GNU>:-O3>
 	--expt-relaxed-constexpr	
-    #-Xptxas -warn-spills -res-usage    
+    -Xptxas -warn-spills -res-usage   
+	--ptxas-options=-v	
     #-G    
 )
 

--- a/include/rxmesh/iterator.cuh
+++ b/include/rxmesh/iterator.cuh
@@ -19,14 +19,13 @@ struct Iterator
                         const uint16_t* not_owned_local_id,
                         int             shift = 0)
         : m_patch_output(patch_output),
-          m_patch_offset(patch_offset),
           m_patch_id(patch_id),
           m_num_owned(num_owned),
           m_not_owned_patch(not_owned_patch),
           m_not_owned_local_id(not_owned_local_id),
           m_shift(shift)
     {
-        set(local_id, offset_size);
+        set(local_id, offset_size, patch_offset);
     }
 
     Iterator(const Iterator& orig) = default;
@@ -45,7 +44,7 @@ struct Iterator
         if (lid < m_num_owned) {
             return {m_patch_id, lid};
         } else {
-            lid -= m_num_owned;            
+            lid -= m_num_owned;
             return {m_not_owned_patch[lid], m_not_owned_local_id[lid]};
         }
     }
@@ -109,7 +108,6 @@ struct Iterator
 
    private:
     const LocalT*   m_patch_output;
-    const uint16_t* m_patch_offset;
     const uint32_t  m_patch_id;
     const uint32_t* m_not_owned_patch;
     const uint16_t* m_not_owned_local_id;
@@ -120,13 +118,15 @@ struct Iterator
     uint16_t        m_current;
     int             m_shift;
 
-    __device__ void set(const uint16_t local_id, const uint32_t offset_size)
+    __device__ void set(const uint16_t  local_id,
+                        const uint32_t  offset_size,
+                        const uint16_t* patch_offset)
     {
         m_current  = 0;
         m_local_id = local_id;
         if (offset_size == 0) {
-            m_begin = m_patch_offset[m_local_id];
-            m_end   = m_patch_offset[m_local_id + 1];
+            m_begin = patch_offset[m_local_id];
+            m_end   = patch_offset[m_local_id + 1];
         } else {
             m_begin = m_local_id * offset_size;
             m_end   = (m_local_id + 1) * offset_size;

--- a/include/rxmesh/kernels/edge_flip.cuh
+++ b/include/rxmesh/kernels/edge_flip.cuh
@@ -38,9 +38,11 @@ __device__ __inline__ void edge_flip(PatchInfo&       patch_info,
         s_ef32[i] = INVALID32;
     }
 
-    // load FE into shared memory
-    load_patch_FE<blockThreads>(patch_info,
-                                reinterpret_cast<LocalEdgeT*>(s_fe));
+    // load FE into shared memory    
+    load_async(reinterpret_cast<const uint16_t*>(patch_info.fe),
+               num_faces * 3,
+               reinterpret_cast<uint16_t*>(s_fe),
+               true);
     __syncthreads();
 
     // Transpose FE into EF so we obtain the two incident triangles to
@@ -114,8 +116,10 @@ __device__ __inline__ void edge_flip(PatchInfo&       patch_info,
             s_fe, 3 * num_faces, reinterpret_cast<uint16_t*>(patch_info.fe));
 
         // load EV in the same place that was used to store EF
-        load_patch_EV<blockThreads>(patch_info,
-                                    reinterpret_cast<LocalVertexT*>(s_ev));
+        load_async(reinterpret_cast<const uint16_t*>(patch_info.ev),
+                   num_edges * 2,
+                   reinterpret_cast<uint16_t*>(s_ev),
+                   true);
         __syncthreads();
 
         // Now, we go over all edge that has been flipped

--- a/include/rxmesh/kernels/loader.cuh
+++ b/include/rxmesh/kernels/loader.cuh
@@ -2,12 +2,38 @@
 
 #include <assert.h>
 #include <stdint.h>
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/memcpy_async.h>
+#include <cuda/barrier>//for cuda::aligned_size_t
+
 #include "rxmesh/context.h"
 #include "rxmesh/local.h"
 #include "rxmesh/types.h"
+#include "rxmesh/util/util.h"
 
 namespace rxmesh {
 namespace detail {
+
+template <typename T, typename SizeT>
+__device__ __inline__ void load_async(const T*    in,
+                                      const SizeT size,
+                                      T*          out,
+                                      bool        with_wait)
+{
+    namespace cg       = cooperative_groups;
+    cg::thread_block g = cg::this_thread_block();
+
+    cg::memcpy_async(
+        block,
+        out,
+        in,
+        cuda::aligned_size_t<128>(expand_to_align(sizeof(T) * size)));
+
+    if (with_wait) {
+        cg::wait(block);
+    }
+}
 
 template <uint32_t blockThreads>
 __device__ __forceinline__ void load_uint16(const uint16_t* in,
@@ -91,6 +117,46 @@ __device__ __forceinline__ void load_mesh(const PatchInfo& patch_info,
                 reinterpret_cast<LocalEdgeT*>(&s_ev[patch_info.num_edges * 2]);
         }
         load_patch_FE<blockThreads>(patch_info, s_fe);
+    }
+}
+
+template <Op op, uint32_t blockThreads>
+__device__ __forceinline__ void load_mesh(const PatchInfo& patch_info,
+                                          uint16_t*&       s_ev,
+                                          uint16_t*&       s_fe,
+                                          bool             with_wait)
+{
+    // assert(s_ev == s_fe);
+
+    switch (op) {
+        case Op::VV: {
+            break;
+        }
+        case Op::VE: {
+            break;
+        }
+        case Op::VF: {
+            break;
+        }
+        case Op::FV: {
+            break;
+        }
+        case Op::FE: {
+            break;
+        }
+        case Op::FF: {
+            break;
+        }
+        case Op::EV: {
+            break;
+        }
+        case Op::EF: {
+            break;
+        }
+        default: {
+            assert(1 != 1);
+            break;
+        }
     }
 }
 

--- a/include/rxmesh/kernels/loader.cuh
+++ b/include/rxmesh/kernels/loader.cuh
@@ -61,67 +61,14 @@ __device__ __forceinline__ void load_uint16(const uint16_t* in,
 
 
 /**
- * @brief load the patch FE
- * @param patch_info input patch info
- * @param patch_faces output FE
- * @return
- */
-template <uint32_t blockThreads>
-__device__ __forceinline__ void load_patch_FE(const PatchInfo& patch_info,
-                                              LocalEdgeT*      fe)
-{
-    load_uint16<blockThreads>(reinterpret_cast<const uint16_t*>(patch_info.fe),
-                              patch_info.num_faces * 3,
-                              reinterpret_cast<uint16_t*>(fe));
-}
-
-/**
- * @brief load the patch EV
- * @param patch_info input patch info
- * @param ev output EV
- * @return
- */
-template <uint32_t blockThreads>
-__device__ __forceinline__ void load_patch_EV(const PatchInfo& patch_info,
-                                              LocalVertexT*    ev)
-{
-    load_uint16<blockThreads>(reinterpret_cast<const uint16_t*>(patch_info.ev),
-                              patch_info.num_edges * 2,
-                              reinterpret_cast<uint16_t*>(ev));
-}
-
-/**
- * @brief load the patch topology i.e., EV and FE
- * @param patch_info input patch info
- * @param load_ev input indicates if we should load EV
- * @param load_fe input indicates if we should load FE
+ * @brief load the patch topology based on the requirements of a query operation
+ * @tparam op the query operation 
+ * @param patch_info input patch info 
  * @param s_ev where EV will be loaded
  * @param s_fe where FE will be loaded
+ * @param with_wait wither to add a sync at the end 
  * @return
  */
-template <uint32_t blockThreads>
-__device__ __forceinline__ void load_mesh(const PatchInfo& patch_info,
-                                          const bool       load_ev,
-                                          const bool       load_fe,
-                                          LocalVertexT*&   s_ev,
-                                          LocalEdgeT*&     s_fe)
-{
-
-    if (load_ev) {
-        load_patch_EV<blockThreads>(patch_info, s_ev);
-    }
-    // load patch faces
-    if (load_fe) {
-        if (load_ev) {
-            // if we loaded the edges, then we need to move where
-            // s_fe is pointing at to avoid overwrite
-            s_fe =
-                reinterpret_cast<LocalEdgeT*>(&s_ev[patch_info.num_edges * 2]);
-        }
-        load_patch_FE<blockThreads>(patch_info, s_fe);
-    }
-}
-
 template <Op op>
 __device__ __forceinline__ void load_mesh_async(const PatchInfo& patch_info,
                                                 uint16_t*&       s_ev,

--- a/include/rxmesh/kernels/query_dispatcher.cuh
+++ b/include/rxmesh/kernels/query_dispatcher.cuh
@@ -70,6 +70,7 @@ __device__ __inline__ void query_block_dispatcher(const PatchInfo& patch_info,
     }
 
     // 2) Load the patch info
+    // TODO need shift shrd_mem to be aligned to 128-byte boundary
     extern __shared__ uint16_t shrd_mem[];
     // LocalVertexT* s_ev = reinterpret_cast<LocalVertexT*>(shrd_mem);
     // LocalEdgeT*   s_fe = reinterpret_cast<LocalEdgeT*>(shrd_mem);

--- a/include/rxmesh/kernels/query_dispatcher.cuh
+++ b/include/rxmesh/kernels/query_dispatcher.cuh
@@ -33,13 +33,6 @@ __device__ __inline__ void query_block_dispatcher(const PatchInfo& patch_info,
 {
     static_assert(op != Op::EE, "Op::EE is not supported!");
 
-    constexpr bool load_fe = (op == Op::VF || op == Op::EE || op == Op::EF ||
-                              op == Op::FV || op == Op::FE || op == Op::FF);
-    constexpr bool loed_ev = (op == Op::VV || op == Op::VE || op == Op::VF ||
-                              op == Op::EV || op == Op::FV);
-    static_assert(loed_ev || load_fe,
-                  "At least faces or edges needs to be loaded");
-
     // Check if any of the mesh elements are in the active set
     // input mapping does not need to be stored in shared memory since it will
     // be read coalesced, we can rely on L1 cache here

--- a/include/rxmesh/kernels/query_dispatcher.cuh
+++ b/include/rxmesh/kernels/query_dispatcher.cuh
@@ -33,11 +33,11 @@ __device__ __inline__ void query_block_dispatcher(const PatchInfo& patch_info,
 {
     static_assert(op != Op::EE, "Op::EE is not supported!");
 
-    constexpr bool load_fe  = (op == Op::VF || op == Op::EE || op == Op::EF ||
+    constexpr bool load_fe = (op == Op::VF || op == Op::EE || op == Op::EF ||
                               op == Op::FV || op == Op::FE || op == Op::FF);
-    constexpr bool loead_ev = (op == Op::VV || op == Op::VE || op == Op::VF ||
-                               op == Op::EV || op == Op::FV);
-    static_assert(loead_ev || load_fe,
+    constexpr bool loed_ev = (op == Op::VV || op == Op::VE || op == Op::VF ||
+                              op == Op::EV || op == Op::FV);
+    static_assert(loed_ev || load_fe,
                   "At least faces or edges needs to be loaded");
 
     // Check if any of the mesh elements are in the active set
@@ -73,7 +73,7 @@ __device__ __inline__ void query_block_dispatcher(const PatchInfo& patch_info,
     extern __shared__ uint16_t shrd_mem[];
     LocalVertexT*              s_ev = reinterpret_cast<LocalVertexT*>(shrd_mem);
     LocalEdgeT*                s_fe = reinterpret_cast<LocalEdgeT*>(shrd_mem);
-    load_mesh<blockThreads>(patch_info, loead_ev, load_fe, s_ev, s_fe);
+    load_mesh<blockThreads>(patch_info, loed_ev, load_fe, s_ev, s_fe);
 
     not_owned_patch    = reinterpret_cast<uint32_t*>(shrd_mem);
     not_owned_local_id = shrd_mem;

--- a/include/rxmesh/kernels/query_dispatcher.cuh
+++ b/include/rxmesh/kernels/query_dispatcher.cuh
@@ -72,11 +72,8 @@ __device__ __inline__ void query_block_dispatcher(const PatchInfo& patch_info,
     // 2) Load the patch info
     // TODO need shift shrd_mem to be aligned to 128-byte boundary
     extern __shared__ uint16_t shrd_mem[];
-    // LocalVertexT* s_ev = reinterpret_cast<LocalVertexT*>(shrd_mem);
-    // LocalEdgeT*   s_fe = reinterpret_cast<LocalEdgeT*>(shrd_mem);
-    // load_mesh<blockThreads>(patch_info, loed_ev, load_fe, s_ev, s_fe);
-    uint16_t* s_ev = shrd_mem;
-    uint16_t* s_fe = shrd_mem;
+    uint16_t*                  s_ev = shrd_mem;
+    uint16_t*                  s_fe = shrd_mem;
     load_mesh_async<op>(patch_info, s_ev, s_fe, true);
 
     not_owned_patch    = reinterpret_cast<uint32_t*>(shrd_mem);

--- a/include/rxmesh/kernels/rxmesh_queries.cuh
+++ b/include/rxmesh/kernels/rxmesh_queries.cuh
@@ -134,8 +134,10 @@ __device__ __forceinline__ void v_v_oreinted(const PatchInfo& patch_info,
     uint16_t*   s_fe    = &s_output_value[2 * num_edges];
     uint16_t*   s_ef    = &s_fe[3 * num_faces + (3 * num_faces) % 2];
     LocalEdgeT* temp_fe = reinterpret_cast<LocalEdgeT*>(s_fe);
-    load_patch_FE<blockThreads>(patch_info, temp_fe);
-
+    load_async(reinterpret_cast<const uint16_t*>(patch_info.fe),
+               num_faces * 3,
+               reinterpret_cast<uint16_t*>(temp_fe),
+               true);
 
     for (uint32_t i = threadIdx.x; i < num_edges * 2; i += blockThreads) {
         s_ef[i] = INVALID16;
@@ -221,7 +223,10 @@ __device__ __forceinline__ void v_v_oreinted(const PatchInfo& patch_info,
     // Load EV into s_ef since both has the same size (2*#E)
     s_ev                  = s_ef;
     LocalVertexT* temp_ev = reinterpret_cast<LocalVertexT*>(s_ef);
-    load_patch_EV<blockThreads>(patch_info, temp_ev);
+    load_async(reinterpret_cast<const uint16_t*>(patch_info.ev),
+               num_edges * 2,
+               reinterpret_cast<uint16_t*>(temp_ev),
+               true);
 
     __syncthreads();
 

--- a/include/rxmesh/rxmesh.cpp
+++ b/include/rxmesh/rxmesh.cpp
@@ -596,8 +596,9 @@ void RXMesh::build_device()
 
 
         // allocate and copy patch topology to the device
-        CUDA_ERROR(cudaMalloc((void**)&d_patch.ev,
-                              d_patch.num_edges * 2 * sizeof(LocalVertexT)));
+        CUDA_ERROR(cudaMalloc(
+            (void**)&d_patch.ev,
+            expand_to_align(d_patch.num_edges * 2 * sizeof(LocalVertexT))));
         CUDA_ERROR(cudaMemcpy(d_patch.ev,
                               m_h_patches_ev[p].data(),
                               d_patch.num_edges * 2 * sizeof(LocalVertexT),
@@ -605,8 +606,9 @@ void RXMesh::build_device()
         m_h_patches_info[p].ev =
             reinterpret_cast<LocalVertexT*>(m_h_patches_ev[p].data());
 
-        CUDA_ERROR(cudaMalloc((void**)&d_patch.fe,
-                              d_patch.num_faces * 3 * sizeof(LocalEdgeT)));
+        CUDA_ERROR(cudaMalloc(
+            (void**)&d_patch.fe,
+            expand_to_align(d_patch.num_faces * 3 * sizeof(LocalEdgeT))));
         CUDA_ERROR(cudaMemcpy(d_patch.fe,
                               m_h_patches_fe[p].data(),
                               d_patch.num_faces * 3 * sizeof(LocalEdgeT),
@@ -660,15 +662,17 @@ void RXMesh::build_device()
                 }
 
                 // Copy to device
-                CUDA_ERROR(cudaMalloc((void**)&d_not_owned_id,
-                                      sizeof(LocalT) * num_not_owned));
+                CUDA_ERROR(cudaMalloc(
+                    (void**)&d_not_owned_id,
+                    expand_to_align(sizeof(LocalT) * num_not_owned)));
                 CUDA_ERROR(cudaMemcpy(d_not_owned_id,
                                       h_not_owned_id,
                                       sizeof(LocalT) * num_not_owned,
                                       cudaMemcpyHostToDevice));
 
-                CUDA_ERROR(cudaMalloc((void**)&d_not_owned_patch,
-                                      sizeof(uint32_t) * num_not_owned));
+                CUDA_ERROR(cudaMalloc(
+                    (void**)&d_not_owned_patch,
+                    expand_to_align(sizeof(uint32_t) * num_not_owned)));
                 CUDA_ERROR(cudaMemcpy(d_not_owned_patch,
                                       h_not_owned_patch,
                                       sizeof(uint32_t) * num_not_owned,

--- a/include/rxmesh/rxmesh_static.h
+++ b/include/rxmesh/rxmesh_static.h
@@ -185,11 +185,7 @@ class RXMeshStatic : public RXMesh
                             const void*              kernel,
                             const bool               oriented = false) const
     {
-        static_assert(
-            blockThreads && ((blockThreads & (blockThreads - 1)) == 0),
-            " RXMeshStatic::prepare_launch_box() CUDA block size should be of "
-            "power 2");
-
+        
         launch_box.blocks         = this->m_num_patches;
         launch_box.smem_bytes_dyn = 0;
 

--- a/include/rxmesh/rxmesh_static.h
+++ b/include/rxmesh/rxmesh_static.h
@@ -701,16 +701,7 @@ class RXMeshStatic : public RXMesh
 
         size_t dynamic_smem = 0;
 
-        // given an initial number of bytes, increase this number such that it
-        // multiple of alignment
-        auto expand_to_align = [](uint32_t init_bytes,
-                                  uint32_t alignment = 128) -> uint32_t {
-            int remainder = init_bytes % alignment;
-            if (remainder == 0) {
-                return init_bytes;
-            }
-            return init_bytes + alignment - remainder;
-        };
+        
 
         // Let a "segment" mean an array that will be loaded from global memory
         // to shared memory. Since we use memcpy_async API, every segment should

--- a/include/rxmesh/util/macros.h
+++ b/include/rxmesh/util/macros.h
@@ -9,7 +9,7 @@ namespace rxmesh {
 typedef uint8_t flag_t;
 
 // TRANSPOSE_ITEM_PER_THREAD
-constexpr uint32_t TRANSPOSE_ITEM_PER_THREAD = 11;
+constexpr uint32_t TRANSPOSE_ITEM_PER_THREAD = 9;
 
 // used for integer rounding
 #define DIVIDE_UP(num, divisor) (num + divisor - 1) / (divisor)

--- a/include/rxmesh/util/util.h
+++ b/include/rxmesh/util/util.h
@@ -345,6 +345,19 @@ inline std::string extract_file_name(const std::string& full_path)
     return filename.substr(lastslash + 1);
 }
 
+/**
+ * @brief given an initial number of bytes, increase this number such that it
+ * multiple of alignment
+ */
+inline uint32_t expand_to_align(uint32_t init_bytes, uint32_t alignment = 128)
+{
+    uint32_t remainder = init_bytes % alignment;
+    if (remainder == 0) {
+        return init_bytes;
+    }
+    return init_bytes + alignment - remainder;
+};
+
 namespace detail {
 
 /**

--- a/include/rxmesh/util/util.h
+++ b/include/rxmesh/util/util.h
@@ -386,5 +386,29 @@ inline std::pair<uint32_t, uint32_t> edge_key(const uint32_t v0,
     uint32_t j = std::min(v0, v1);
     return std::make_pair(i, j);
 }
+
+/**
+ * @brief given a pointer, this function returns a pointer to the first location
+ * at the boundary of a given alignment size. This what std:align does but it
+ * does not work with CUDA so this a stripped down version of it.
+ * @tparam T type of the pointer
+ * @param byte_alignment number of bytes to get the pointer to be aligned to
+ * @param ptr input/output pointer pointing at first usable location. On return,
+ * it will be properly aligned to the beginning of the first element that is
+ * aligned to alignment
+ */
+template <typename T>
+__device__ __host__ __inline__ void align(const std::size_t byte_alignment,
+                                          T*&               ptr) noexcept
+{
+    const uint64_t intptr    = reinterpret_cast<uint64_t>(ptr);
+    const uint64_t remainder = intptr % byte_alignment;
+    if (remainder == 0) {
+        return;
+    }
+    const uint64_t aligned = intptr + byte_alignment - remainder;
+    ptr                    = reinterpret_cast<T*>(aligned);
+}
+
 }  // namespace detail
 }  // namespace rxmesh

--- a/include/rxmesh/util/util.h
+++ b/include/rxmesh/util/util.h
@@ -349,7 +349,9 @@ inline std::string extract_file_name(const std::string& full_path)
  * @brief given an initial number of bytes, increase this number such that it
  * multiple of alignment
  */
-inline uint32_t expand_to_align(uint32_t init_bytes, uint32_t alignment = 128)
+__device__ __host__ __inline__ uint32_t expand_to_align(
+    uint32_t init_bytes,
+    uint32_t alignment = 128)
 {
     uint32_t remainder = init_bytes % alignment;
     if (remainder == 0) {

--- a/tests/RXMesh_test/rxmesh_test_main.cu
+++ b/tests/RXMesh_test/rxmesh_test_main.cu
@@ -17,12 +17,14 @@ struct RXMeshTestArg
     char**      argv          = argv;
 } rxmesh_args;
 
+// clang-format off
 #include "test_higher_queries.h"
 #include "test_queries.h"
 #include "test_attribute.cuh"
 #include "test_for_each.h"
 #include "test_edge_flip.h"
 #include "test_validate.h"
+// clang-format on
 
 int main(int argc, char** argv)
 {

--- a/tests/RXMesh_test/test_queries.h
+++ b/tests/RXMesh_test/test_queries.h
@@ -41,7 +41,7 @@ TEST(RXMeshStatic, Oriented_VV)
     output->reset(VertexHandle(), rxmesh::DEVICE);
 
     // launch box
-    constexpr uint32_t      blockThreads = 256;
+    constexpr uint32_t      blockThreads = 320;
     LaunchBox<blockThreads> launch_box;
     rxmesh.prepare_launch_box(
         {Op::VV},

--- a/tests/RXMesh_test/test_queries.h
+++ b/tests/RXMesh_test/test_queries.h
@@ -129,7 +129,7 @@ void launcher(const std::vector<std::vector<uint32_t>>& Faces,
     using namespace rxmesh;
 
     // launch box
-    constexpr uint32_t      blockThreads = 256;
+    constexpr uint32_t      blockThreads = 320;
     LaunchBox<blockThreads> launch_box;
     rxmesh.prepare_launch_box({op},
                               launch_box,

--- a/tests/RXMesh_test/test_util.cu
+++ b/tests/RXMesh_test/test_util.cu
@@ -99,6 +99,29 @@ TEST(Util, AtomicAdd)
     EXPECT_TRUE(test_atomicAdd<uint8_t>()) << "uint8_t failed";
 }
 
+
+TEST(Util, Align)
+{
+    using Type             = float;
+    const size_t num_bytes = sizeof(Type) * 1024;
+    const size_t alignment = 128;
+
+    Type* ptr = (Type*)malloc(num_bytes);
+
+    char* ptr_mis_aligned = reinterpret_cast<char*>(ptr) + 1;
+
+    Type* ptr_aligned    = reinterpret_cast<Type*>(ptr_mis_aligned);
+    void* ptr_aligned_gt = ptr_aligned;
+    rxmesh::detail::align(alignment, ptr_aligned);
+
+    std::size_t spc;
+    void*       ret = std::align(alignment, sizeof(Type), ptr_aligned_gt, spc);
+
+    free(ptr);
+
+    EXPECT_EQ(ptr_aligned, ptr_aligned_gt);
+}
+
 TEST(Util, BlockMatrixTranspose)
 {
     constexpr uint32_t numRows   = 542;


### PR DESCRIPTION
This PR integrates CUDA `memcpy_async` to load data from global memory to shared memory. There is alignment requirements that are important to [obtain maximum performance](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#aligned_size_t) that is ignore for now and will be fixed in future PR. However, we pad global and shared memory as a starting point to support these alignment requirements 