### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -2,7 +2,7 @@ name: Windows
 on: [push, pull_request, workflow_dispatch]
 jobs:
   WindowsRun:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: Jimver/cuda-toolkit@v0.2.4
         id: cuda-toolkit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,13 @@ project(RXMesh
         VERSION 0.2.0 
         LANGUAGES C CXX CUDA)
 
-set(USE_POLYSCOPE "ON" CACHE BOOL "Enable Ployscope for visualization")
+if (WIN32)
+    set(USE_POLYSCOPE "ON" CACHE BOOL "Enable Ployscope for visualization")
+    message(STATUS "Polyscope is enabled")
+else()
+    set(USE_POLYSCOPE "OFF" CACHE BOOL "Enable Ployscope for visualization")
+    message(STATUS "Polyscope is disabled")
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)

--- a/include/rxmesh/kernels/loader.cuh
+++ b/include/rxmesh/kernels/loader.cuh
@@ -5,8 +5,6 @@
 
 #include <cooperative_groups.h>
 #include <cooperative_groups/memcpy_async.h>
-//#include <cuda/barrier>  //for cuda::aligned_size_t
-
 #include "rxmesh/context.h"
 #include "rxmesh/local.h"
 #include "rxmesh/types.h"
@@ -27,9 +25,7 @@ __device__ __inline__ void load_async(const T*    in,
     cg::memcpy_async(
         block,
         out,
-        in,
-        // TODO need to revisit this
-        // cuda::aligned_size_t<128>(expand_to_align(sizeof(T) * size)));
+        in,        
         sizeof(T) * size);
 
     if (with_wait) {

--- a/include/rxmesh/rxmesh.cpp
+++ b/include/rxmesh/rxmesh.cpp
@@ -602,9 +602,8 @@ void RXMesh::build_device()
 
 
         // allocate and copy patch topology to the device
-        CUDA_ERROR(cudaMalloc(
-            (void**)&d_patch.ev,
-            expand_to_align(d_patch.num_edges * 2 * sizeof(LocalVertexT))));
+        CUDA_ERROR(cudaMalloc((void**)&d_patch.ev,
+                              d_patch.num_edges * 2 * sizeof(LocalVertexT)));
         CUDA_ERROR(cudaMemcpy(d_patch.ev,
                               m_h_patches_ev[p].data(),
                               d_patch.num_edges * 2 * sizeof(LocalVertexT),
@@ -612,9 +611,8 @@ void RXMesh::build_device()
         m_h_patches_info[p].ev =
             reinterpret_cast<LocalVertexT*>(m_h_patches_ev[p].data());
 
-        CUDA_ERROR(cudaMalloc(
-            (void**)&d_patch.fe,
-            expand_to_align(d_patch.num_faces * 3 * sizeof(LocalEdgeT))));
+        CUDA_ERROR(cudaMalloc((void**)&d_patch.fe,
+                              d_patch.num_faces * 3 * sizeof(LocalEdgeT)));
         CUDA_ERROR(cudaMemcpy(d_patch.fe,
                               m_h_patches_fe[p].data(),
                               d_patch.num_faces * 3 * sizeof(LocalEdgeT),
@@ -668,17 +666,15 @@ void RXMesh::build_device()
                 }
 
                 // Copy to device
-                CUDA_ERROR(cudaMalloc(
-                    (void**)&d_not_owned_id,
-                    expand_to_align(sizeof(LocalT) * num_not_owned)));
+                CUDA_ERROR(cudaMalloc((void**)&d_not_owned_id,
+                                      sizeof(LocalT) * num_not_owned));
                 CUDA_ERROR(cudaMemcpy(d_not_owned_id,
                                       h_not_owned_id,
                                       sizeof(LocalT) * num_not_owned,
                                       cudaMemcpyHostToDevice));
 
-                CUDA_ERROR(cudaMalloc(
-                    (void**)&d_not_owned_patch,
-                    expand_to_align(sizeof(uint32_t) * num_not_owned)));
+                CUDA_ERROR(cudaMalloc((void**)&d_not_owned_patch,
+                                      sizeof(uint32_t) * num_not_owned));
                 CUDA_ERROR(cudaMemcpy(d_not_owned_patch,
                                       h_not_owned_patch,
                                       sizeof(uint32_t) * num_not_owned,

--- a/tests/Polyscope_test/CMakeLists.txt
+++ b/tests/Polyscope_test/CMakeLists.txt
@@ -1,25 +1,27 @@
-add_executable( Polyscope_test )
+if (USE_POLYSCOPE)
+	add_executable( Polyscope_test )
 
-set( SOURCE_LIST   
-	test_polyscope.cu
-)
+	set( SOURCE_LIST   
+		test_polyscope.cu
+	)
 
-target_sources( Polyscope_test 
-    PRIVATE
-	${SOURCE_LIST}    
-)
+	target_sources( Polyscope_test 
+	    PRIVATE
+		${SOURCE_LIST}    
+	)
 
-set_target_properties( Polyscope_test PROPERTIES FOLDER "tests")
+	set_target_properties( Polyscope_test PROPERTIES FOLDER "tests")
 
-set_property(TARGET Polyscope_test PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+	set_property(TARGET Polyscope_test PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
-source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "Polyscope_test" FILES ${SOURCE_LIST})
+	source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "Polyscope_test" FILES ${SOURCE_LIST})
 
-target_link_libraries( Polyscope_test
-	PRIVATE polyscope
-    PRIVATE RXMesh_header_lib 
-    PRIVATE RXMesh_lib
-	PRIVATE gtest_main
-)
+	target_link_libraries( Polyscope_test
+		PRIVATE polyscope
+	    PRIVATE RXMesh_header_lib 
+	    PRIVATE RXMesh_lib
+		PRIVATE gtest_main
+	)
 
-#gtest_discover_tests( Polyscope_test )
+	#gtest_discover_tests( Polyscope_test )
+endif()

--- a/tests/RXMesh_test/test_util.cu
+++ b/tests/RXMesh_test/test_util.cu
@@ -111,14 +111,14 @@ TEST(Util, Align)
     char* ptr_mis_aligned = reinterpret_cast<char*>(ptr) + 1;
 
     Type* ptr_aligned    = reinterpret_cast<Type*>(ptr_mis_aligned);
-    void* ptr_aligned_gt = ptr_aligned;
     rxmesh::detail::align(alignment, ptr_aligned);
-
-    std::size_t spc;
-    void*       ret = std::align(alignment, sizeof(Type), ptr_aligned_gt, spc);
-
+    
+    void* ptr_aligned_gt = reinterpret_cast<void*>(ptr_mis_aligned);
+    std::size_t spc = num_bytes;
+    void*       ret = std::align(alignment, sizeof(char), ptr_aligned_gt, spc);
+    
     free(ptr);
-
+    EXPECT_NE(ret, nullptr);
     EXPECT_EQ(ptr_aligned, ptr_aligned_gt);
 }
 


### PR DESCRIPTION
- Remove the padding of shared memory to align with 128 bytes since it does not give any performance boost. 
- By default , disable polyscope on Linux
- Fix align unit test 